### PR TITLE
Fix/swipeable overflowing leftAction

### DIFF
--- a/src/screens/punch-list/compose/punch-card/punch-card.style.js
+++ b/src/screens/punch-list/compose/punch-card/punch-card.style.js
@@ -47,6 +47,7 @@ export const RemoveCard = styled.TouchableOpacity`
   border-top-left-radius: ${moderateScale(8)}px;
   border-bottom-left-radius: ${moderateScale(8)}px;
   border: ${({ theme }) => theme.colors.disabled};
+  margin-right: ${moderateScale(-8)}px;
 `;
 
 export const RemoveCardText = styled.Text`


### PR DESCRIPTION
After spenting a lot of time trying to figure out how to stop the swipeable overflow bug (mentioned by @belgamo), the only solution that I found was to set a negative margin-right

## Old apearence
![Screenshot from 2022-05-27 18-52-32](https://user-images.githubusercontent.com/58452911/170794179-828da6dd-0940-4542-864b-afa0dc28ee06.png)

# now
![Screenshot from 2022-05-27 18-54-06](https://user-images.githubusercontent.com/58452911/170794231-19c127ca-33c1-49d7-a7d4-51678bc013a1.png)

